### PR TITLE
Added optional 'token' param

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ npm install -g gitlab-ci-lint
 
   Options:
 
-    -h, --help       output usage information
-    -V, --version    output the version number
-    -u, --url [URL]  Use alternative Gitlab URL
+    -h, --help            output usage information
+    -V, --version         output the version number
+    -u, --url [URL]       Use alternative Gitlab URL
+    -t, --token [TOKEN]   Provide Gitlab personal access token, when it's needed
 ```
 
 #### examples
@@ -33,16 +34,28 @@ gitlab-ci-lint
 gitlab-ci-lint <filename>
 ```
 
-* Alternative Gitlab url
+* Alternative Gitlab URL
 ```
 gitlab-ci-lint --url https://git.my.corp
 ```
 
-### API
+* With Gitlab personal access token
+```
+gitlab-ci-lint --token token-string-here123
+```
 
+### API
+* with `filename` param
 ```
 const gitlabCILint = require('gitlab-ci-lint')
 
 gitlabCILint.lintFile('.gitlab-ci.yml')
+  .then((result) => console.log(result))
+```
+* with `filename`, `baseURL` and `token` params, accordingly
+```
+const gitlabCILint = require('gitlab-ci-lint')
+
+gitlabCILint.lintFile('.gitlab-ci.yml', 'https://git.my.corp', 'token-string-here123')
   .then((result) => console.log(result))
 ```

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,17 +1,25 @@
 import fs from 'mz/fs'
 import rp from 'request-promise'
 
-export function lint (content, baseURL = 'https://gitlab.com') {
-  return rp({
+export function lint (content, baseURL = 'https://gitlab.com', token) {
+  const options = {
     uri: `${baseURL}/api/v4/ci/lint`,
     json: true,
     method: 'POST',
     body: {
       content
     }
-  })
+  }
+
+  if (token !== undefined) {
+    options.qs = {
+      private_token: token
+    }
+  }
+
+  return rp(options)
 }
 
-export function lintFile (filename, baseURL) {
-  return fs.readFile(filename).then((data) => lint(data.toString(), baseURL))
+export function lintFile (filename, baseURL, token) {
+  return fs.readFile(filename).then((data) => lint(data.toString(), baseURL, token))
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -7,9 +7,10 @@ commander
   .version(pkg.version)
   .usage('[options] <file>')
   .option('-u, --url [URL]', 'Use alternative Gitlab URL')
+  .option('-t, --token [TOKEN]', 'Provide Gitlab personal access token, when it\'s needed')
   .parse(process.argv)
 
-lintFile(commander.args[0] || '.gitlab-ci.yml', commander.url)
+lintFile(commander.args[0] || '.gitlab-ci.yml', commander.url, commander.token)
   .then((result) => {
     result.errors.forEach((error) => console.error(error))
     process.exit(result.status === 'valid' ? 0 : 1)


### PR DESCRIPTION
According to the new [Gitlab release 13.9.1 ](https://about.gitlab.com/releases/2021/02/23/gitlab-13-9-1-released/), there is an update of authorization for lint.

From now, it's required to provide a token for every call to the `lint` endpoint (if Gitlab "signup_enabled" setting is disabled - see this [MR](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/54492)).